### PR TITLE
🐛 fix(backend/login): ft-oauth/callback redirection & set return type to auth api

### DIFF
--- a/packages/server/src/auth/dto/login.dto.ts
+++ b/packages/server/src/auth/dto/login.dto.ts
@@ -1,8 +1,20 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class LoginDto {
+export class LoginRequestDto {
   @ApiProperty()
   credential: string;
   @ApiProperty()
   clientId: string;
+}
+
+export class LoginResponseDto {
+  @ApiProperty()
+  needFtOAuth: boolean;
+  @ApiProperty()
+  refreshToken: string;
+}
+
+export class TokenRefreshDto {
+  @ApiProperty()
+  refreshToken: string;
 }


### PR DESCRIPTION
…s to auth api (#32)

#32

### 💡 작업 동기 (Motivation)
- ft-oauth callback 에러처리(리다이렉션으로 인한 상태 코드 사용 불가)


### 💬 변경 사항 요약 (Key changes) 
- ft-oauth/callback 내부 에러 발생 시, 프론트엔드 URL/logout으로 리다이렉션
- API 반환 타입 명시


### ✅  체크리스트
- [x] 콘솔에 오류나 경고가 없습니다.

### 📣 리뷰어들에게 요청사항

- close #32 
