### PR TITLE
Fix/35/login fail

### DIFF
--- a/packages/client/app/src/ErrorPage/ErrorPage.tsx
+++ b/packages/client/app/src/ErrorPage/ErrorPage.tsx
@@ -5,16 +5,20 @@ import { AxiosError } from 'axios';
 import { RouteList } from '../AppRouter';
 import { useSetAtom } from 'jotai';
 import { needFtOAuthAtom } from '../Login/atoms/needFtOAuthAtom';
+import { googleCredentialAtom } from '../Login/atoms/googleCredentialAtom';
 
-// todo: fix to redirect
 export const ErrorPage = () => {
   const error = useRouteError();
+  const setGoogleCredential = useSetAtom(googleCredentialAtom);
   const setNeedFtOAuth = useSetAtom(needFtOAuthAtom);
 
   console.warn('logging error', error);
 
   if (error instanceof AxiosError) {
     if (error.response?.status === 401) {
+      // force user to login again
+      // todo: replace with useLogout();
+      setGoogleCredential(null);
       return <Navigate to={RouteList.LOGIN} replace={true} />;
     }
 

--- a/packages/client/app/src/FTOAuth/FTOAuth.tsx
+++ b/packages/client/app/src/FTOAuth/FTOAuth.tsx
@@ -14,7 +14,7 @@ export const FtOAuth = () => {
   return (
     <CheckLogin>
       <a href="http://localhost:3000/auth/ft-oauth">
-        <button>asdfa</button>
+        <button>ft auth</button>
       </a>
     </CheckLogin>
   );

--- a/packages/client/app/src/FTOAuth/FTOAuth.tsx
+++ b/packages/client/app/src/FTOAuth/FTOAuth.tsx
@@ -10,7 +10,7 @@ export const FtOAuth = () => {
   if (!needFtOAuth) {
     return <Navigate to={RouteList.ROOT} />;
   }
-  // todo: return user with no refresh token
+
   return (
     <CheckLogin>
       <a href="http://localhost:3000/auth/ft-oauth">

--- a/packages/client/app/src/Login/atoms/refreshTokenAtom.ts
+++ b/packages/client/app/src/Login/atoms/refreshTokenAtom.ts
@@ -2,7 +2,6 @@ import { atom } from 'jotai';
 
 const refreshTokenBaseAtom = atom<string | null>(null);
 
-// todo: refactor here
 const localStorageKey = 'refresh-token';
 
 export const refreshTokenAtom = atom<string | null, string>(
@@ -21,11 +20,25 @@ export const refreshTokenAtom = atom<string | null, string>(
   }
 );
 
+/**
+ * @description derived from refreshTokenAtom.
+ */
 export const needLoginAtom = atom<boolean>((get) => {
   const refreshToken = get(refreshTokenAtom);
   return !hasState(refreshToken);
 });
 
+// utils
+
 const hasState = (atom: string | null) => {
   return atom !== null;
 };
+
+/**
+ * @description use only in axios interceptors.
+ */
+export const localRefreshToken = {
+  get: () => localStorage.getItem(localStorageKey),
+  set: (newRefreshToken: string) =>
+    localStorage.setItem(localStorageKey, newRefreshToken),
+} as const;

--- a/packages/client/app/src/Login/hooks/useGoogleButtonDiv.ts
+++ b/packages/client/app/src/Login/hooks/useGoogleButtonDiv.ts
@@ -32,7 +32,15 @@ export const useGoogleButtonDiv = () => {
       throw 'gapi script load fail';
     }
 
-    if (!(isLoaded && window.google && googleButtonDiv.current)) {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!isGoogleScriptLoadSuccess(window.google)) {
+      throw 'gapi script load fail';
+    }
+
+    if (!isDivElementRendered(googleButtonDiv.current)) {
       return;
     }
 
@@ -44,15 +52,21 @@ export const useGoogleButtonDiv = () => {
     );
 
     window.google.accounts.id.prompt();
-  }, [
-    isLoaded,
-    isError,
-    window.google,
-    window.innerWidth,
-    googleButtonDiv.current,
-  ]);
+  }, [isLoaded, isError, googleButtonWidth, googleButtonDiv.current]);
 
   return googleButtonDiv;
+};
+
+const isGoogleScriptLoadSuccess = (
+  googleObject: Google | undefined
+): googleObject is Google => {
+  return googleObject !== undefined;
+};
+
+const isDivElementRendered = (
+  divRef: HTMLDivElement | null
+): divRef is HTMLDivElement => {
+  return divRef !== null;
 };
 
 const getGoogleRenderButtonOption = (

--- a/packages/client/app/src/Login/hooks/useGoogleButtonWidth.ts
+++ b/packages/client/app/src/Login/hooks/useGoogleButtonWidth.ts
@@ -27,7 +27,7 @@ export const useGoogleButtonWidth = (): googleButtonWidthType => {
     window.addEventListener('resize', windowEventHandler);
 
     return () => window.removeEventListener('resize', windowEventHandler);
-  }, [window.innerWidth]);
+  }, []);
 
   return windowWidth;
 };

--- a/packages/client/app/src/axiosConfig.ts
+++ b/packages/client/app/src/axiosConfig.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { localRefreshToken } from './Login/atoms/refreshTokenAtom';
 
 export const axiosInstance = axios.create({
   // todo
@@ -12,13 +13,12 @@ export const axiosInstance = axios.create({
   },
 });
 
-// todo: sync with backend
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
     if (error?.response?.status === 401) {
-      // todo
-      const refreshToken = localStorage.getItem('refresh-token');
+      const refreshToken = localRefreshToken.get();
+
       console.debug('401 occured, axios is now handling');
       if (refreshToken === null) {
         return Promise.reject(error);

--- a/packages/client/app/src/vite-env.d.ts
+++ b/packages/client/app/src/vite-env.d.ts
@@ -2,6 +2,9 @@
 
 interface ImportMetaEnv {
   readonly VITE_BACKEND_EP: string;
+  /**
+   * @description google gsi client url
+   */
   readonly VITE_GAPI_URL: string;
   readonly VITE_GAPI_CLIENT_ID: string;
 }


### PR DESCRIPTION
### 💡 작업 동기 (Motivation)
- google credential이 남은 상태에서 401을 받을 경우, 쿼리가 무한 재실행되는 현상
- close #35 

### 💬 변경 사항 요약 (Key changes) 
- error page에서 clear하고 navigate하도록 수정.
- 추후에 logout 구현 후 해당 hook으로 대체 예정

### ✅  체크리스트
- [x] 콘솔에 오류나 경고가 없습니다.
